### PR TITLE
Fixes gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source :rubygems
 
-gem 'ansi'
-gem 'hashr'
 gem 'rb-fsevent', git: 'git://github.com/niw/rb-fsevent.git'
 
 group :test do

--- a/space.gemspec
+++ b/space.gemspec
@@ -12,6 +12,10 @@ Gem::Specification.new do |s|
   s.summary       = "space"
   s.description   = "space."
 
+  s.add_dependency 'ansi', '~> 1.4.2'
+  s.add_dependency 'hashr', '~> 0.0.20'
+  s.add_dependency 'rb-fsevent'
+
   s.files         = Dir.glob("{lib/**/*,[A-Z]*}")
   s.platform      = Gem::Platform::RUBY
   s.executables   = ['space']


### PR DESCRIPTION
`gem install space` does not currently install the dependencies, because they are specified in the `Gemfile` and not the `.gemspec`. Unfortunately the `rb-fsevent` dependency must use the published gem, otherwise things will not work at all, not sure if things will break because of this, but with this patch the installation instructions in the README work, at least.
