### PR TITLE
Fix Bundler error `Unknown switches '--no-lock'`

### DIFF
--- a/lib/space/model/repo/bundle.rb
+++ b/lib/space/model/repo/bundle.rb
@@ -4,7 +4,7 @@ module Space
       class Bundle
         include Source
 
-        commands check: 'bundle check --no-lock',
+        commands check: 'bundle check',
                  list:  'bundle list'
 
         watch 'Gemfile',


### PR DESCRIPTION
Last stable Bundler (version 1.1.3) has not a  `--no-lock` switch for `check` command. That's why I think we should fix it.
