### PR TITLE
[PoC] Fix improper Dashboard list indexing

### DIFF
--- a/lib/space/model/project.rb
+++ b/lib/space/model/project.rb
@@ -28,7 +28,7 @@ module Space
 
       def number(name)
         if number = names.index(name)
-          number + 1
+          number
         else
           names << name
           number(name)


### PR DESCRIPTION
Having two repos I'm facing improper list indexing in Dashboard. Here is how it looking for me https://gist.github.com/a454501c92026be915bf. Pressing key `1` that corresponds unexising repo is closing space. 

This fix is Proof of Concept, 'cause I didn't dive into the inner logic of Dashboard, and removing this `+1` is most obvious way to fix it.
