### PR TITLE
[PoC] Added New Feature - Basic Repos' Names Autocomplition

### DIFF
--- a/lib/space/app.rb
+++ b/lib/space/app.rb
@@ -21,6 +21,9 @@ module Space
     private
 
       def cli_loop
+        Readline.completion_append_character = ""
+        Readline.completion_proc = ->(s){ project.names.grep(/#{Regexp.escape(s)}/) }
+
         loop do
           print "\e[3;0H"
           line = Readline.readline(views.first.send(:prompt), true) || break


### PR DESCRIPTION
I am not Readline guru, but I found some neat feature in it - simple autocomplition. I added the very basic completion for project repositories names. It invokes by entering few letter and tab, just like in the shell, except you can complete by middle letters, for example: you have repos `travis-hub` and `travis-core`, by entering `co` and hitting Tab you'll get complete for `travis-core`. But if you'll enter `tra` and hit Tab twice, trying to complete it, Dashboard will be overwritten with complete variants, and only Dashboard Refresh can remove it, and that's quite disturbing, and that's why I've called this feature PoC. If you'll like you can merge this feature as it is.
