### PR TITLE
Fix dependencies in gemspec

### DIFF
--- a/space.gemspec
+++ b/space.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |s|
   s.summary       = "space"
   s.description   = "space."
 
-  s.add_dependency 'ansi', '~> 1.4.2'
-  s.add_dependency 'hashr', '~> 0.0.20'
-  s.add_dependency 'rb-fsevent'
+  s.add_runtime_dependency 'ansi', '~> 1.4.2'
+  s.add_runtime_dependency 'hashr', '~> 0.0.20'
+  s.add_runtime_dependency 'rb-fsevent'
 
   s.files         = Dir.glob("{lib/**/*,[A-Z]*}")
   s.platform      = Gem::Platform::RUBY


### PR DESCRIPTION
During space gem installation with RubyGems 1.8.22 ansi, hashr and rb-fsevent are not installed. So I configured dependencies explicitly to `runtime` and it works properly now. Please, verify it. Thanks.
